### PR TITLE
fix: add permission sync to ephemeral lobby.py cog

### DIFF
--- a/functions/tool/lobby.py
+++ b/functions/tool/lobby.py
@@ -3,9 +3,9 @@ from os import makedirs, path
 from typing import TYPE_CHECKING
 
 from aiosqlite import connect
-from discord import (ButtonStyle, Embed, Interaction, Member, Role, StageChannel, Object,
-                     PermissionOverwrite, VoiceChannel, VoiceState,
-                     app_commands)
+from discord import (ButtonStyle, Embed, Interaction, Member, NotFound, Object,
+                     PermissionOverwrite, Role, StageChannel, VoiceChannel,
+                     VoiceState, app_commands)
 from discord.ext import commands
 from discord.ui import Button, Modal, TextInput, View, button
 
@@ -20,6 +20,7 @@ class VoiceControlView(View):
         super().__init__(timeout=None)
         self.channel = channel
         self.owner = owner
+        self.connect_overwrites: dict[Role | Member, bool | None] = {}
 
     async def interaction_check(self, interaction: Interaction) -> bool:
         if interaction.user != self.owner:
@@ -32,9 +33,27 @@ class VoiceControlView(View):
     @button(label="Lock", style=ButtonStyle.red)
     async def lock_channel(self, interaction: Interaction, button: Button) -> None:
         if interaction.guild is None: return
-        overwrite = self.channel.overwrites_for(interaction.guild.default_role)
-        overwrite.connect = False
-        await self.channel.set_permissions(interaction.guild.default_role, overwrite=overwrite)
+        overwrites = self.channel.overwrites
+        default_role = interaction.guild.default_role
+        overwrites.setdefault(
+            default_role, self.channel.overwrites_for(default_role)
+        )
+        self.connect_overwrites.clear()
+        for target, overwrite in overwrites.items():
+            if target == self.owner or (
+                target != default_role and overwrite.connect is not True
+            ):
+                continue
+            if isinstance(target, Object):
+                if target.type is Role:
+                    continue
+                try:
+                    target = await interaction.guild.fetch_member(target.id)
+                except NotFound:
+                    continue
+            self.connect_overwrites[target] = overwrite.connect
+            overwrite.connect = False
+            await self.channel.set_permissions(target, overwrite=overwrite)
 
         button.disabled = True
         if isinstance(btn2 := self.children[1], Button):
@@ -45,9 +64,11 @@ class VoiceControlView(View):
     @button(label="Unlock", style=ButtonStyle.green, disabled=True)
     async def unlock_channel(self, interaction: Interaction, button: Button) -> None:
         if interaction.guild is None: return
-        overwrite = self.channel.overwrites_for(interaction.guild.default_role)
-        overwrite.connect = None
-        await self.channel.set_permissions(interaction.guild.default_role, overwrite=overwrite)
+        for target, connect_permission in self.connect_overwrites.items():
+            overwrite = self.channel.overwrites_for(target)
+            overwrite.connect = connect_permission
+            await self.channel.set_permissions(target, overwrite=overwrite)
+        self.connect_overwrites.clear()
 
         button.disabled = True
         if isinstance(btn1 := self.children[0], Button):
@@ -194,10 +215,10 @@ class LobbyCog(commands.GroupCog, group_name="lobby", group_description="Dynamic
 
     async def _create_lobby(self, member: Member, generator: VoiceChannel | StageChannel) -> None:
         guild = member.guild
-        overwrites: dict[Role | Member | Object, PermissionOverwrite] = {
-            guild.default_role: PermissionOverwrite(connect=True),
-            member: PermissionOverwrite(connect=True, move_members=True, manage_channels=True),
-        }
+        overwrites = generator.overwrites
+        overwrites.setdefault(member, PermissionOverwrite()).update(
+            connect=True, move_members=True, manage_channels=True
+        )
 
         new_channel = await guild.create_voice_channel(
             name=f"⏲️ {member.display_name}'s lobby",

--- a/tests/tool/test_lobby.py
+++ b/tests/tool/test_lobby.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from aiosqlite import connect
+from discord import PermissionOverwrite
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
@@ -30,20 +31,21 @@ class DummyBot:
 
 
 class DummyVoiceChannel:
-    def __init__(self):
+    def __init__(self, overwrites=None):
         self.last_role = None
         self.last_overwrite = None
         self.last_name = None
-        self._overwrite = SimpleNamespace(connect=None)
+        self.overwrites = overwrites or {}
         self.set_permissions = AsyncMock(side_effect=self._set_permissions)
         self.edit = AsyncMock(side_effect=self._edit)
 
-    def overwrites_for(self, _role):
-        return self._overwrite
+    def overwrites_for(self, role):
+        return self.overwrites.setdefault(role, PermissionOverwrite())
 
     async def _set_permissions(self, role, overwrite):
         self.last_role = role
         self.last_overwrite = overwrite
+        self.overwrites[role] = overwrite
 
     async def _edit(self, name):
         self.last_name = name
@@ -82,9 +84,17 @@ async def test_voice_control_interaction_check_rejects_non_owner():
 
 @pytest.mark.asyncio
 async def test_voice_control_lock_and_unlock_toggle_permissions_and_buttons():
-    channel = DummyVoiceChannel()
     owner = object()
-    guild = SimpleNamespace(default_role=object())
+    default_role = object()
+    allowed_role = object()
+    channel = DummyVoiceChannel(
+        {
+            default_role: PermissionOverwrite(),
+            allowed_role: PermissionOverwrite(connect=True),
+            owner: PermissionOverwrite(connect=True),
+        }
+    )
+    guild = SimpleNamespace(default_role=default_role)
     view = VoiceControlView(channel, owner)
     interaction = _make_interaction(user=owner, guild=guild)
 
@@ -95,14 +105,18 @@ async def test_voice_control_lock_and_unlock_toggle_permissions_and_buttons():
 
     assert lock_button.disabled is True
     assert unlock_button.disabled is False
-    assert channel.last_overwrite.connect is False
+    assert channel.overwrites[default_role].connect is False
+    assert channel.overwrites[allowed_role].connect is False
+    assert channel.overwrites[owner].connect is True
     interaction.followup.send.assert_awaited_with(":lock: Channel locked.", ephemeral=True)
 
     await unlock_button.callback(interaction)
 
     assert lock_button.disabled is False
     assert unlock_button.disabled is True
-    assert channel.last_overwrite.connect is None
+    assert channel.overwrites[default_role].connect is None
+    assert channel.overwrites[allowed_role].connect is True
+    assert channel.overwrites[owner].connect is True
     interaction.followup.send.assert_awaited_with(
         ":unlock: Channel unlocked.", ephemeral=True
     )
@@ -172,6 +186,55 @@ async def test_cleanup_ghost_lobbies_removes_missing_channels(tmp_path):
         async with db.execute("SELECT channel_id FROM lobby_active ORDER BY channel_id") as cursor:
             rows = await cursor.fetchall()
     assert rows == [(22,)]
+
+
+@pytest.mark.asyncio
+async def test_create_lobby_inherits_overwrites_and_elevates_owner(tmp_path):
+    bot = DummyBot(tmp_path / "lobby.db")
+    cog = LobbyCog(bot)
+    await cog._init_db()
+
+    class DummyMember:
+        display_name = "Owner"
+        mention = "@Owner"
+
+        def __init__(self, guild):
+            self.guild = guild
+            self.move_to = AsyncMock()
+
+    default_role = object()
+    allowed_role = object()
+    new_channel = SimpleNamespace(id=303, send=AsyncMock(), delete=AsyncMock())
+    guild = SimpleNamespace(
+        default_role=default_role,
+        create_voice_channel=AsyncMock(return_value=new_channel),
+    )
+    member = DummyMember(guild)
+    generator = SimpleNamespace(
+        category=object(),
+        overwrites={
+            default_role: PermissionOverwrite(
+                view_channel=False, connect=False
+            ),
+            allowed_role: PermissionOverwrite(
+                view_channel=True, connect=True, speak=False
+            ),
+            member: PermissionOverwrite(speak=False),
+        },
+    )
+
+    await cog._create_lobby(member, generator)
+
+    overwrites = guild.create_voice_channel.await_args.kwargs["overwrites"]
+    assert overwrites[default_role].view_channel is False
+    assert overwrites[default_role].connect is False
+    assert overwrites[allowed_role].view_channel is True
+    assert overwrites[allowed_role].connect is True
+    assert overwrites[allowed_role].speak is False
+    assert overwrites[member].speak is False
+    assert overwrites[member].connect is True
+    assert overwrites[member].move_members is True
+    assert overwrites[member].manage_channels is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

## Description
Static permission assignment on lobby.py caused certain users to not be able to see expected ephemeral voice channel. This fixes #171

## Related Issue(s)
#171

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around x) -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring or optimization
- [ ] Other (please describe):

## Checklist
<!-- Mark items with an "x" (no spaces around x) -->

- [X] My code follows the code style of this project
- [X] I have tested my changes locally
- [X] My changes generate no new warnings or errors
- [X] I have updated the documentation accordingly (if applicable)
- [X] I have added tests to cover my changes (if applicable)

## Screenshots (if applicable)
<!-- If your PR includes visual changes, include screenshots here -->

## Additional Information
<!-- Add any other context about the PR here -->